### PR TITLE
Emacs 26: Emacs not response when press Enter in shell mode

### DIFF
--- a/lisp/vc/vc-hg.el
+++ b/lisp/vc/vc-hg.el
@@ -1289,12 +1289,10 @@ REV is the revision to check out into WORKFILE."
      )))
 
 (defun vc-hg-log-incoming (buffer remote-location)
-  (vc-setup-buffer buffer)
   (vc-hg-command buffer 1 nil "incoming" "-n" (unless (string= remote-location "")
 						remote-location)))
 
 (defun vc-hg-log-outgoing (buffer remote-location)
-  (vc-setup-buffer buffer)
   (vc-hg-command buffer 1 nil "outgoing" "-n" (unless (string= remote-location "")
 						remote-location)))
 

--- a/lisp/vc/vc-hg.el
+++ b/lisp/vc/vc-hg.el
@@ -1289,10 +1289,12 @@ REV is the revision to check out into WORKFILE."
      )))
 
 (defun vc-hg-log-incoming (buffer remote-location)
+  (vc-setup-buffer buffer)
   (vc-hg-command buffer 1 nil "incoming" "-n" (unless (string= remote-location "")
 						remote-location)))
 
 (defun vc-hg-log-outgoing (buffer remote-location)
+  (vc-setup-buffer buffer)
   (vc-hg-command buffer 1 nil "outgoing" "-n" (unless (string= remote-location "")
 						remote-location)))
 

--- a/src/sysdep.c
+++ b/src/sysdep.c
@@ -1792,7 +1792,15 @@ handle_arith_signal (int sig)
 
 /* Alternate stack used by SIGSEGV handler below.  */
 
-static unsigned char sigsegv_stack[SIGSTKSZ];
+/* Storage for the alternate signal stack.
+   64 KiB is not too large for Emacs, and is large enough
+   for all known platforms.  Smaller sizes may run into trouble.
+   For example, libsigsegv 2.6 through 2.8 have a bug where some
+   architectures use more than the Linux default of an 8 KiB alternate
+   stack when deciding if a fault was caused by stack overflow.  */
+static max_align_t sigsegv_stack[(64 * 1024
+				  + sizeof (max_align_t) - 1)
+				 / sizeof (max_align_t)];
 
 
 /* Return true if SIGINFO indicates a stack overflow.  */


### PR DESCRIPTION
Windows 10 (64 bit), Emacs 26.1

1. I download Emacs 26 from here : http://ftp.gnu.org/gnu/emacs/windows/emacs-26/emacs-26.1-x86_64.zip
2. Unpack and run pure Emacs (no external packages)
3. Connect android device to my computer
4. `M-x shell`
5. Run the next command `adb logcat -vtime`. Tool `logcat `- is a tool from Google to see android's device logging. It's very helpful.
6. This tool (`logcat`) generate many text interactively in shell.
7. So I press button `arrow up` and move cursor to the center of screen. 
8. Text is continues to be generated. 
9. And now I press button `Enter`
10. As result Emacs not response any more. Show progress bar forever. Nothing help. Only kill Emacs process from Task Manager.

Here screenshot:
![emacs_freeze](https://user-images.githubusercontent.com/303539/46243538-270b2d00-c3de-11e8-8ca9-8e390cee4d82.jpg)

Why this is happened? 

