### PR TITLE
Add debug declaration to widget-specify-insert

### DIFF
--- a/lisp/wid-edit.el
+++ b/lisp/wid-edit.el
@@ -414,6 +414,7 @@ the :notify function can't know the new value.")
 
 (defmacro widget-specify-insert (&rest form)
   "Execute FORM without inheriting any text properties."
+  (declare (debug body))
   `(save-restriction
     (let ((inhibit-read-only t)
 	  (inhibit-modification-hooks t))


### PR DESCRIPTION
important for user-defined editable-list widget with a modified set of buttons.
In that use-case function `widget-editable-list-entry-create` needs to be imitated for that purpose.