### PR TITLE
remove map restriction on org-capture header

### DIFF
--- a/lisp/org/org-capture.el
+++ b/lisp/org/org-capture.el
@@ -513,9 +513,8 @@ Turning on this mode runs the normal hook `org-capture-mode-hook'."
   (setq-local
    header-line-format
    (substitute-command-keys
-    "\\<org-capture-mode-map>Capture buffer.  Finish \
-`\\[org-capture-finalize]', refile `\\[org-capture-refile]', \
-abort `\\[org-capture-kill]'.")))
+    "Capture buffer.  Finish `\\[org-capture-finalize]', refile \
+`\\[org-capture-refile]', abort `\\[org-capture-kill]'.")))
 
 ;;; The main commands
 


### PR DESCRIPTION
org-capture-header only allows keys from the org-capture-map, meaning shorter, custom bindings such as spacemacs's ", ," won't show up. This change removes the restriction and thus allows the bindings to show up 😄.