### PR TITLE
Qnx build

### DIFF
--- a/build-aux/config.sub
+++ b/build-aux/config.sub
@@ -2,7 +2,7 @@
 # Configuration validation subroutine script.
 #   Copyright 1992-2020 Free Software Foundation, Inc.
 
-timestamp='2020-08-17'
+timestamp='2020-09-05'
 
 # This file is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by
@@ -1277,7 +1277,6 @@ case $vendor in
 esac
 
 # Decode manufacturer-specific aliases for certain operating systems.
-
 if test x$basic_os != x
 then
 
@@ -1367,13 +1366,7 @@ case $os in
 		os=psos
 		;;
 	qnx*)
-		case $cpu in
-		    x86 | i*86)
-			;;
-		    *)
-			os=nto-$os
-			;;
-		esac
+		os=qnx
 		;;
 	hiux*)
 		os=hiuxwe2
@@ -1722,7 +1715,7 @@ case $os in
 	     | skyos* | haiku* | rdos* | toppers* | drops* | es* \
 	     | onefs* | tirtos* | phoenix* | fuchsia* | redox* | bme* \
 	     | midnightbsd* | amdhsa* | unleashed* | emscripten* | wasi* \
-	     | nsk* | powerunix* | genode* | zvmoe* )
+	     | nsk* | powerunix* | genode* | zvmoe* | qnx* )
 		;;
 	# This one is extra strict with allowed versions
 	sco3.2v2 | sco3.2v[4-9]* | sco5v6*)

--- a/build-aux/config.sub
+++ b/build-aux/config.sub
@@ -1277,6 +1277,7 @@ case $vendor in
 esac
 
 # Decode manufacturer-specific aliases for certain operating systems.
+
 if test x$basic_os != x
 then
 

--- a/configure.ac
+++ b/configure.ac
@@ -785,10 +785,7 @@ case "${canonical}" in
   *-nto-qnx* )
     opsys=qnxnto
     test -z "$CC" && CC=qcc
-    CFLAGS="$CFLAGS -D__NO_EXT_QNX"
-    if test "$with_unexec" = yes; then
-      LDFLAGS="-N2MB $LDFLAGS"
-    fi
+    LDFLAGS="-N2M $LDFLAGS"
   ;;
 
   ## Intel 386 machines where we don't care about the manufacturer.


### PR DESCRIPTION
Fix the QNX build:
1. Recent changes to config.sub broke the detection of QNX systems.
2. The linker flag for increasing the main stack size is wrong. Also, the flag should be set unconditionally, now that the default dumper has changed.
3. The __NO_EXT_QNX flag is no longer needed, and is masking the declaration of memset_s().