### PR TITLE
man.el: display-buffer without 'not-this-window, respect display-buffer-alist

### DIFF
--- a/lisp/man.el
+++ b/lisp/man.el
@@ -1229,7 +1229,7 @@ See the variable `Man-notify-method' for the different notification behaviors."
       ('friendly
        (and (frame-live-p saved-frame)
             (select-frame saved-frame))
-       (display-buffer man-buffer 'not-this-window))
+       (display-buffer man-buffer))
       ('thrifty
        (and (frame-live-p saved-frame)
             (select-frame saved-frame))


### PR DESCRIPTION
I prefer to have `display-buffer-same-window` to get predictable buffer switching behavior. I suggest to remove the hard-coded `'not-this-window` in `man.el`.  User may customize the `display-buffer-alist` option to get desired behavior.