### PR TITLE
Haiku doesn't have libdl too

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4345,8 +4345,8 @@ if test "${with_native_compilation}" != "no"; then
     case "${opsys}" in
       # mingw32 loads the library dynamically.
       mingw32) ;;
-      # OpenBSD doesn't have libdl, all the functions are in libc
-      netbsd|openbsd)
+      # OpenBSD and Haiku don't have libdl, all the functions are in libc
+      netbsd|openbsd|haiku)
         LIBGCCJIT_LIBS="-lgccjit" ;;
       darwin)
         LIBGCCJIT_CFLAGS="${MAC_CFLAGS}"


### PR DESCRIPTION
Up to now we didn't have libgccjit, with the upcomming update to our compiler it is enabled, this fixes the build (checked against latest 29.1~rc1).