### PR TITLE
GNUstep:In a multi-display setup, the main menu does not to a new display when emacs window is moved

### DIFF
--- a/src/nsterm.m
+++ b/src/nsterm.m
@@ -5802,6 +5802,10 @@ ns_term_shutdown (int sig)
 			  selector: @selector(updateMonitors:)
 			      name: NSApplicationDidChangeScreenParametersNotification
 			    object: nil];
+  [notification_center addObserver: self
+			  selector: @selector(windowDidChangeScreen:)
+			      name: NSWindowDidChangeScreenNotification
+			    object: nil];
 #endif
 
   return self;
@@ -6032,6 +6036,11 @@ ns_term_shutdown (int sig)
   XSETTERMINAL (ie.arg, x_display_list->terminal);
 
   kbd_buffer_store_event (&ie);
+}
+
+- (void) windowDidChangeScreen: (NSNotification *) notification
+{
+  [[NSApp mainMenu] windowDidChangeScreen:notification];
 }
 #endif
 


### PR DESCRIPTION
In a multi-display setup, the main menu does not move from one display to
another when the Emacs window is moved between displays.  This improvement
adds a notification listener that notifies the mainMenu that the
NSWindowDidChangeScreenNotification has occured.

In other Apps this callback is registered automatically.  In NSMenu, the
applicationDidFinishLaunch method registers this for the mainMenu.
However, the way emacs construcgts GNUstep menus in nsmenu.m, constructs
menus in a different manner.

Note: this proposed modification handles one emacs window moving between
different displays, but does not handle the case where there are multiple
emacs windows.  In that case, the menu should appear on the display on
which the emacs frame is shown.…y to

another when the Emacs window is moved between displays.  This improvement adds a notification listener that notifies the mainMenu that the NSWindowDidChangeScreenNotification has occured.

In other Apps this callback is registered automatically.  In NSMenu, the applicationDidFinishLaunch method registers this for the mainMenu. However, the way emacs construcgts GNUstep menus in nsmenu.m, constructs menus in a different manner.

Note: this proposed modification handles one emacs window moving between different displays, but does not handle the case where there are multiple emacs windows.  In that case, the menu should appear on the display on which the emacs frame is shown.