### PR TITLE
cperl-mode: Don't Apply 'font-lock-warning-face to "\h" and "\v", etc.

### DIFF
--- a/lisp/progmodes/cperl-mode.el
+++ b/lisp/progmodes/cperl-mode.el
@@ -5013,7 +5013,7 @@ recursive calls in starting lines of here-documents."
 				(cperl-postpone-fontification
 				 (- (point) 2) (- (point) 1) 'face
 				 (if (memq qtag
-					   (append "ghijkmoqvFHIJKMORTVY" nil))
+					   (append "gijkmoqFIJKMOTY" nil))
 				     font-lock-warning-face
 				   my-cperl-REx-0length-face))
 				(if (and (eq (char-after b) qtag)


### PR DESCRIPTION
From: https://www.regular-expressions.info/shorthand.html#more
```
Perl 5.10 introduced \h and \v. \h matches horizontal whitespace,
which includes the tab and all characters in the "space separator"
Unicode category. It is the same as [\t\p{Zs}]. \v matches "vertical
whitespace", which includes all characters treated as line breaks
in the Unicode standard.
```

See also:
- https://perldoc.perl.org/perl5100delta#Vertical-and-horizontal-whitespace,-and-linebreak
```
Regular expressions now recognize the \v and \h escapes that match
vertical and horizontal whitespace, respectively. \V and \H logically
match their complements.

\R matches a generic linebreak, that is, vertical whitespace, plus
the multi-character sequence "\x0D\x0A".
```