### PR TITLE
Allow "backquote" to be used as a substitute for ` in backquote expan…

### DIFF
--- a/lisp/emacs-lisp/backquote.el
+++ b/lisp/emacs-lisp/backquote.el
@@ -170,7 +170,8 @@ LEVEL is only used internally and indicates the nesting level:
             (error "Multiple args to ,@ are not supported: %S" s)
           (cons 2 (nth 1 s)))
       (backquote-delay-process s (1- level))))
-   ((eq (car s) backquote-backquote-symbol)
+   ((or (eq (car s) backquote-backquote-symbol)
+	(eq (car s) 'backquote))
       (backquote-delay-process s (1+ level)))
    (t
     (let ((rest s)


### PR DESCRIPTION
…sion

As per an error reported years ago:

https://stackoverflow.com/a/17395105/62365

I'm adding the fixed version tested. It just equals using `backquote` instead of the actual backquote symbol '\` in all situations, even when expanded by this backquote function.