### PR TITLE
Fix typo "which-fuction-mode" in mhtml-ts-mode.el comment

### DIFF
--- a/lisp/textmodes/mhtml-ts-mode.el
+++ b/lisp/textmodes/mhtml-ts-mode.el
@@ -339,7 +339,7 @@ NODE and PARENT are ignored."
 (defvar mhtml-ts-mode--prettify-symbols-alist js--prettify-symbols-alist
   "Alist of symbol prettifications for various supported languages.")
 
-;; In order to support `which-fuction-mode' we should define
+;; In order to support `which-function-mode' we should define
 ;; a function that return the defun name.
 ;; In a multilingual treesit mode, this can be implemented simply by
 ;; calling language-specific functions.


### PR DESCRIPTION

**Repo:** emacs-mirror/emacs (⭐ 6000)
**Type:** docs
**Files changed:** 1
**Lines:** +1/-1

## What
Corrects a misspelling of `which-function-mode` (written as `which-fuction-mode`)
in an explanatory comment in `lisp/textmodes/mhtml-ts-mode.el`.

## Why
The comment references the actual Emacs minor mode `which-function-mode`. The
misspelling makes the comment misleading and breaks searches/grep for the real
symbol when developers look for which modes a given file supports.

## Testing
Pure comment change; no behavior affected. Verified via `git diff` that only the
comment text changed and that no other occurrence of "fuction" remains in
`lisp/`.

## Risk
Low — single-character comment fix, no code paths touched.
